### PR TITLE
Use CMake's Build Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ cmake-easyinstall git-<https-url>.git [cmake-options]
 
 - bash
 - cmake
-- curl
+- curl (for the initial download)
 - git
+- ninja, make, or any other [native build system](https://cmake.org/cmake/help/v3.16/manual/cmake-generators.7.html)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cmake-easyinstall git-<https-url>.git [cmake-options]
 ## Dependencies
 
 - bash
-- cmake
+- cmake 3.12.0+
 - curl (for the initial download)
 - git
 - ninja, make, or any other [native build system](https://cmake.org/cmake/help/v3.16/manual/cmake-generators.7.html)

--- a/cmake-easyinstall
+++ b/cmake-easyinstall
@@ -37,7 +37,7 @@ git clone \
 # execute
 cd ${tmp_dir}/build
 ${CEI_CMAKE} ../src -DCMAKE_BUILD_TYPE=${CEI_CONFIG} "${@:2}"
-cmake --build . --target install --config=${CEI_CONFIG}
+cmake --build . --target install --config ${CEI_CONFIG} --parallel ${CEI_PARALLEL}
 
 # remove temporary directory
 cd -

--- a/cmake-easyinstall
+++ b/cmake-easyinstall
@@ -4,7 +4,7 @@
 #
 # License: BSD-2-Clause
 #
-# dependencies: bash, cmake, curl, git
+# dependencies: bash, cmake 3.12.0+, git
 
 set -eu -o pipefail
 
@@ -17,7 +17,7 @@ fi
 
 # options (undocumented)
 CEI_CMAKE=${CEI_CMAKE:-"cmake"}
-CEI_MAKE=${CEI_MAKE:-"make"}
+CEI_CONFIG=${CEI_CONFIG:-"RelWithDebInfo"}
 CEI_PARALLEL=${CEI_PARALLEL:-"2"}
 
 # create a temporary directory
@@ -36,8 +36,8 @@ git clone \
 
 # execute
 cd ${tmp_dir}/build
-${CEI_CMAKE} ../src "${@:2}"
-${CEI_MAKE} -j${CEI_PARALLEL} install
+${CEI_CMAKE} ../src -DCMAKE_BUILD_TYPE=${CEI_CONFIG} "${@:2}"
+cmake --build . --target install --config=${CEI_CONFIG}
 
 # remove temporary directory
 cd -


### PR DESCRIPTION
Avoid calling make directly.

Use CMake's parallel build control (CMake 3.12+).

Close #2