### PR TITLE
Add: CEI_TMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Just `export CEI_<option>=<value>` to change some defaults:
 - `CEI_PARALLEL`: maximum number of concurrent build processes (default: `2`)
 - `CEI_PREFIX`: installation prefix (default: CMake default)
 - `CEI_SUDO`: set to `"sudo"` for privileged installation (default: "")
+- `CEI_TMP`: build in a unique or fixed-location directory (default: a unique `mktemp` directory)
 
 # Command Line Options
 

--- a/cmake-easyinstall
+++ b/cmake-easyinstall
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2020 Axel Huebl
+# Copyright 2020-2021 Axel Huebl
 #
 # License: BSD-2-Clause
 #
@@ -20,6 +20,7 @@ CEI_CONFIG=${CEI_CONFIG:-"RelWithDebInfo"}
 CEI_PARALLEL=${CEI_PARALLEL:-"2"}
 CEI_PREFIX=${CEI_PREFIX:-""}
 CEI_SUDO=${CEI_SUDO:-""}
+CEI_TMP=${CEI_TMP:-""}
 
 # command line options (take precedence over environment)
 if [ "$#" -lt 1 ]; then
@@ -46,11 +47,16 @@ else
 fi
 
 # create a temporary build directory
-tmp_dir=$(mktemp --help >/dev/null 2>&1 && mktemp -d -t ci-XXXXXXXXXX || mktemp -d "${TMPDIR:-/tmp}"/ci-XXXXXXXXXX)
-if [ $? -ne 0 ]; then
-    echo "Cannot create a temporary directory"
-    exit 2
+if [ -z "${CEI_TMP}" ]; then
+    tmp_dir=$(mktemp --help >/dev/null 2>&1 && mktemp -d -t ci-XXXXXXXXXX || mktemp -d "${TMPDIR:-/tmp}"/ci-XXXXXXXXXX)
+    if [ $? -ne 0 ]; then
+        echo "Cannot create a temporary directory"
+        exit 2
+    fi
+else
+    tmp_dir=${CEI_TMP}
 fi
+rm -rf ${tmp_dir}/build
 mkdir -p ${tmp_dir}/build
 
 # download


### PR DESCRIPTION
Using a uniquely named temporary build directory will interfere with efforts to `ccache` builds, e.g., in CI setups.

The new `CEI_TMP` environment variable allows to set a fixed-location path instead of creating one via `mktemp`.