### PR TITLE
Build w/o `sudo` & Use `cmake --install`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,4 +35,4 @@ jobs:
     - name: Build an Example
       shell: bash
       run: |
-        ./cmake-easyinstall --prefix="C:\\\\Program Files\PNGwriter" git+https://github.com/openPMD/openPMD-api.git
+        ./cmake-easyinstall --prefix="C:\\\\Program Files\openPMD\openPMD-api" git+https://github.com/openPMD/openPMD-api.git

--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ Note: `cmake-options` take precedence over `--prefix` takes precedence over envi
 ## Dependencies
 
 - bash
-- cmake 3.12.0+
+- cmake 3.15.0+
 - git
 - ninja, make, or any other [native build system](https://cmake.org/cmake/help/v3.16/manual/cmake-generators.7.html)

--- a/cmake-easyinstall
+++ b/cmake-easyinstall
@@ -4,7 +4,7 @@
 #
 # License: BSD-2-Clause
 #
-# dependencies: bash, cmake 3.12.0+, git
+# dependencies: bash, cmake 3.15.0+, git
 
 set -eu -o pipefail
 
@@ -73,23 +73,24 @@ git clone \
   --depth 1 --shallow-submodules \
   ${git_url} ${git_branch} ${tmp_dir}/src
 
-# execute
+# configure
 cd ${tmp_dir}/build
 if [ -z "${CEI_PREFIX}" ]; then
     ${CEI_CMAKE} ../src -DCMAKE_BUILD_TYPE=${CEI_CONFIG} ${cmake_opts}
 else
     ${CEI_CMAKE} ../src -DCMAKE_BUILD_TYPE=${CEI_CONFIG} -DCMAKE_INSTALL_PREFIX="${CEI_PREFIX}" ${cmake_opts}
 fi
+
+# build
+${CEI_CMAKE} --build . --config ${CEI_CONFIG} --parallel ${CEI_PARALLEL}
+
+# install
 if [ -z "${CEI_SUDO}" ]; then
-    ${CEI_CMAKE} --build . --target install --config ${CEI_CONFIG} --parallel ${CEI_PARALLEL}
+    ${CEI_CMAKE} --install . --config ${CEI_CONFIG}
 else
-    ${CEI_SUDO} ${CEI_CMAKE} --build . --target install --config ${CEI_CONFIG} --parallel ${CEI_PARALLEL}
+    ${CEI_SUDO} ${CEI_CMAKE} --install . --config ${CEI_CONFIG}
 fi
 
 # remove temporary directory
 cd -
-if [ -z "${CEI_SUDO}" ]; then
-    rm -rf ${tmp_dir}
-else
-    ${CEI_SUDO} rm -rf ${tmp_dir}
-fi
+rm -rf ${tmp_dir}


### PR DESCRIPTION
Use the CMake 3.15 `--install` switch.

Using `--build . --target install` under `sudo` permissions in combination with compiler launchers such as `ccache` seems to mess with the artifacts permissions in `~/.ccache`. This is problematic for the next build (not the current one), receiving errors of the kind:
```
ccache: error: Failed to create temporary file for /home/runner/.ccache/d/9/53tapk54tlnvm542rfclg37rcd02bjkM.tmp.pM2AVF: Permission denied
```

Update: Ah, most likely, this is because we did not split build & install step before. Nonetheless, let's also use the new API and install independent of the build system :)

Refs.:
- https://cmake.org/cmake/help/v3.23/guide/tutorial/Installing%20and%20Testing.html
- https://cmake.org/cmake/help/v3.15/release/3.15.html#command-line

> The cmake(1) command gained a new --install option. This may be used after building a project to run installation without using the generated build system or the native build tool.